### PR TITLE
Chore - Refactor email

### DIFF
--- a/config/environment.rb
+++ b/config/environment.rb
@@ -4,16 +4,12 @@ require File.expand_path('../application', __FILE__)
 Rails.application.initialize!
 
 ActionMailer::Base.raise_delivery_errors = true
-ActionMailer::Base.delivery_method = :smtp
 ActionMailer::Base.smtp_settings = {
-    :address        => 'smtp.gmail.com',
-    :domain         => 'gmail.com',
-    :port           => 587,
-    :user_name      => 'theateam.veritrans@gmail.com',
-    :password       => 'kakdellaidolaku',
-    :authentication => :plain,
-    :enable_starttls_auto => true,
-    :openssl_verify_mode  => 'none'
+  :port           => ENV['MAILGUN_SMTP_PORT'],
+  :address        => ENV['MAILGUN_SMTP_SERVER'],
+  :user_name      => ENV['MAILGUN_SMTP_LOGIN'],
+  :password       => ENV['MAILGUN_SMTP_PASSWORD'],
+  :domain         => 'aip.heroku.com',
+  :authentication => :plain,
 }
-
-
+ActionMailer::Base.delivery_method = :smtp


### PR DESCRIPTION
Using Mailgun instead of Gmail for sending transactional emails. Still using SMTP though to avoid unnecessary refactor.
